### PR TITLE
Add light-curve tests and CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/test_lightcurves.py
+++ b/tests/test_lightcurves.py
@@ -1,0 +1,59 @@
+import types
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("TripleLensing", types.ModuleType("TripleLensing"))
+module = types.ModuleType("TestML");
+for name in ["get_crit_caus", "getphis_v3", "get_allimgs_with_mu", "testing"]:
+    setattr(module, name, lambda *args, **kwargs: None)
+sys.modules["TestML"] = module
+import numpy as np
+import math
+import VBMicrolensing
+from GCMicrolensing import OneL1S, TwoLens1S
+
+
+def test_onel1s_light_curve():
+    t0 = 0.0
+    tE = 1.0
+    rho = 0.01
+    u0 = 0.1
+    model = OneL1S(t0, tE, rho, [u0])
+
+    vb = VBMicrolensing.VBMicrolensing()
+    vb.RelTol = 1e-3
+    vb.Tol = 1e-3
+    vb.astrometry = True
+
+    expected = np.array([
+        vb.ESPLMag2(math.sqrt(u0 ** 2 + tau ** 2), rho)
+        for tau in model.tau
+    ])
+    actual = np.array([
+        model.VBM.ESPLMag2(math.sqrt(u0 ** 2 + tau ** 2), rho)
+        for tau in model.tau
+    ])
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-6)
+
+
+def test_twolens1s_light_curve():
+    t0 = 0.0
+    tE = 1.0
+    rho = 0.01
+    u0 = 0.1
+    q = 1.0
+    s = 1.5
+    alpha = 0.0
+
+    model = TwoLens1S(t0, tE, rho, [u0], q, s, alpha)
+    system = model.systems[0]
+
+    vb = VBMicrolensing.VBMicrolensing()
+    vb.RelTol = 1e-3
+    vb.Tol = 1e-3
+    vb.astrometry = True
+
+    params = [math.log(s), math.log(q), u0, math.radians(alpha), math.log(rho), math.log(tE), t0]
+    expected, *_ = vb.BinaryLightCurve(params, model.t)
+
+    np.testing.assert_allclose(system['mag'], expected, rtol=1e-6)
+


### PR DESCRIPTION
## Summary
- set up pytest configuration
- add GitHub Actions workflow to run tests
- create unit tests covering `OneL1S` and `TwoLens1S` light-curve generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab1c213cc83289c22488177347833